### PR TITLE
Add go to hermes-agent system packages

### DIFF
--- a/nix/systems/hermes-agent/configuration.nix
+++ b/nix/systems/hermes-agent/configuration.nix
@@ -13,6 +13,7 @@
     with pkgs;
     groups.default
     ++ [
+      go
       # Hermes can make a pr to add any extra packages it needs here
     ];
 


### PR DESCRIPTION
Add Go programming language to the system packages for the Hermes Agent NixOS container.