### PR TITLE
add python3 to hermes-agent system packages

### DIFF
--- a/nix/systems/hermes-agent/configuration.nix
+++ b/nix/systems/hermes-agent/configuration.nix
@@ -22,6 +22,7 @@
     groups.default
     ++ [
       go
+      python3
       # Hermes can make a pr to add any extra packages it needs here
     ];
 


### PR DESCRIPTION
Adds python3 to the hermes-agent container system packages so that cron scripts (like Paperboy) can execute Python directly via /bin/bash wrappers.