### PR TITLE
feat: add hermes-dashboard systemd service with Traefik route

### DIFF
--- a/nix/modules/nixos/hermes-dashboard.nix
+++ b/nix/modules/nixos/hermes-dashboard.nix
@@ -1,0 +1,75 @@
+{
+  ...
+}:
+{
+  flake.modules.nixos.hermes-dashboard =
+    {
+      config,
+      pkgs,
+      lib,
+      ...
+    }:
+
+    let
+      cfg = config.services.hermes-dashboard;
+    in
+    {
+      options.services.hermes-dashboard = {
+        enable = lib.mkEnableOption "the Hermes Agent web dashboard";
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 9119;
+          description = "Port for the dashboard to listen on.";
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "0.0.0.0";
+          description = "Host address for the dashboard to bind to.";
+        };
+
+        openFirewall = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Open the configured port in the firewall.";
+        };
+
+        user = lib.mkOption {
+          type = lib.types.str;
+          default = "hermes";
+          description = "User to run the dashboard service as.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = config.services.hermes-agent.enable;
+            message = "services.hermes-dashboard requires services.hermes-agent.enable = true";
+          }
+        ];
+
+        networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+
+        systemd.services.hermes-dashboard = {
+          description = "Hermes Agent Web Dashboard";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+
+          environment = {
+            HERMES_HOME = "/var/lib/hermes";
+          };
+
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.user;
+            ExecStart = "${config.services.hermes-agent.package}/bin/hermes dashboard --host ${cfg.host} --port ${toString cfg.port} --insecure --no-open";
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
+      };
+    };
+}

--- a/nix/systems/dex/configuration.nix
+++ b/nix/systems/dex/configuration.nix
@@ -580,7 +580,21 @@ rec {
               certResolver = "letsencrypt";
             };
           }
-        ) (dex-services // downloader-services);
+        ) (dex-services // downloader-services)
+        // {
+          hermes-dashboard = {
+            rule = "Host(`hermes.${domain}`)";
+            service = "hermes-dashboard";
+            tls = {
+              domains = [
+                {
+                  main = "*.${domain}";
+                }
+              ];
+              certResolver = "letsencrypt";
+            };
+          };
+        };
 
         services =
           (pkgs.lib.attrsets.mapAttrs' (
@@ -596,7 +610,14 @@ rec {
                 { url = "http://${containers.downloader.localAddress}:${toString port}/"; }
               ];
             }
-          ) downloader-services);
+          ) downloader-services)
+        // {
+          hermes-dashboard = {
+            loadBalancer.servers = [
+              { url = "http://${containers.hermes-agent.localAddress}:9119/"; }
+            ];
+          };
+        };
       };
     };
   };

--- a/nix/systems/hermes-agent/configuration.nix
+++ b/nix/systems/hermes-agent/configuration.nix
@@ -7,6 +7,7 @@
 {
   imports = [
     self.inputs.hermes-agent.nixosModules.default
+    self.modules.nixos.hermes-dashboard
   ];
 
   # https://github.com/NousResearch/hermes-agent/issues/12195
@@ -59,6 +60,13 @@
     settings = {
       model.default = "nvidia/nemotron-3-super-120b-a12b:free";
     };
+  };
+
+  services.hermes-dashboard = {
+    enable = true;
+    port = 9119;
+    host = "0.0.0.0";
+    user = "hermes";
   };
 
   system.stateVersion = "25.05";


### PR DESCRIPTION
## What

- **New module**: `nix/modules/nixos/hermes-dashboard.nix` — a flake-parts NixOS module defining `services.hermes-dashboard` that runs `hermes dashboard --host 0.0.0.0 --port 9119 --insecure --no-open` as a systemd service
- **Container config**: enable `services.hermes-dashboard` in the hermes-agent container at port 9119
- **Traefik config**: add router + load balancer backend for `hermes.dex-lips.duckdns.org` proxying to the container at `10.1.1.2:9119`

## Why

The Hermes web dashboard provides a browser UI for managing config, API keys, and sessions. Running it as a systemd service inside the container with a Traefik route makes it accessible at `https://hermes.dex-lips.duckdns.org`.

## Module options

```nix
services.hermes-dashboard = {
  enable = true;        # default: false
  port = 9119;          # default: 9119
  host = 0.0.0.0;     # default: 0.0.0.0
  openFirewall = false; # default: false
};
```

Requires `services.hermes-agent.enable = true` (enforced by assertion).