### PR TITLE
feat: add hermes-webui NixOS module + Traefik route

### DIFF
--- a/nix/modules/nixos/hermes-webui.nix
+++ b/nix/modules/nixos/hermes-webui.nix
@@ -1,0 +1,87 @@
+{
+  ...
+}:
+{
+  flake.modules.nixos.hermes-webui =
+    {
+      config,
+      pkgs,
+      lib,
+      ...
+    }:
+
+    let
+      cfg = config.services.hermes-webui;
+
+      hermesWebuiSrc = pkgs.fetchFromGitHub {
+        owner = "nesquena";
+        repo = "hermes-webui";
+        rev = "master";
+        sha256 = "1ipn3j48k385sdzw6b89yk400142pvbaby6b4yylvdrd1cp6xlx7";
+      };
+
+      # Extract the Hermes Agent Python interpreter from the hermes wrapper script.
+      # The hermes binary is a bash wrapper that exports HERMES_PYTHON pointing to
+      # the agent's venv Python (which has all agent modules + pyyaml available).
+      webuiStartScript = pkgs.writeShellScript "hermes-webui-start" ''
+        HERMES_PYTHON=$(grep -oP "HERMES_PYTHON='\K[^']+" ${config.services.hermes-agent.package}/bin/hermes)
+
+        export HERMES_WEBUI_HOST="${cfg.host}"
+        export HERMES_WEBUI_PORT="${toString cfg.port}"
+        export HERMES_WEBUI_STATE_DIR="/var/lib/hermes/webui"
+        export HERMES_HOME="/var/lib/hermes"
+
+        mkdir -p /var/lib/hermes/webui
+
+        exec "$HERMES_PYTHON" ${hermesWebuiSrc}/server.py
+      '';
+    in
+    {
+      options.services.hermes-webui = {
+        enable = lib.mkEnableOption "the Hermes Web UI — browser interface for Hermes Agent from nesquena/hermes-webui";
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 8787;
+          description = "Port for the Web UI to listen on.";
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "0.0.0.0";
+          description = "Host address for the Web UI to bind to.";
+        };
+
+        user = lib.mkOption {
+          type = lib.types.str;
+          default = "hermes";
+          description = "User to run the Web UI service as.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = config.services.hermes-agent.enable;
+            message = "services.hermes-webui requires services.hermes-agent.enable = true";
+          }
+        ];
+
+        systemd.services.hermes-webui = {
+          description = "Hermes Web UI — Browser Interface";
+          documentation = [ "https://github.com/nesquena/hermes-webui" ];
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.user;
+            Group = cfg.user;
+            ExecStart = "${webuiStartScript}";
+            Restart = "on-failure";
+            RestartSec = 5;
+          };
+        };
+      };
+    };
+}

--- a/nix/systems/dex/configuration.nix
+++ b/nix/systems/dex/configuration.nix
@@ -594,6 +594,18 @@ rec {
               certResolver = "letsencrypt";
             };
           };
+          hermes-webui = {
+            rule = "Host(`hermes-webui.${domain}`)";
+            service = "hermes-webui";
+            tls = {
+              domains = [
+                {
+                  main = "*.${domain}";
+                }
+              ];
+              certResolver = "letsencrypt";
+            };
+          };
         };
 
         services =
@@ -615,6 +627,11 @@ rec {
           hermes-dashboard = {
             loadBalancer.servers = [
               { url = "http://${containers.hermes-agent.localAddress}:9119/"; }
+            ];
+          };
+          hermes-webui = {
+            loadBalancer.servers = [
+              { url = "http://${containers.hermes-agent.localAddress}:8787/"; }
             ];
           };
         };

--- a/nix/systems/hermes-agent/configuration.nix
+++ b/nix/systems/hermes-agent/configuration.nix
@@ -8,6 +8,7 @@
   imports = [
     self.inputs.hermes-agent.nixosModules.default
     self.modules.nixos.hermes-dashboard
+    self.modules.nixos.hermes-webui
   ];
 
   # https://github.com/NousResearch/hermes-agent/issues/12195
@@ -65,6 +66,13 @@
   services.hermes-dashboard = {
     enable = true;
     port = 9119;
+    host = "0.0.0.0";
+    user = "hermes";
+  };
+
+  services.hermes-webui = {
+    enable = true;
+    port = 8787;
     host = "0.0.0.0";
     user = "hermes";
   };


### PR DESCRIPTION
## What

Adds NixOS support for [nesquena/hermes-webui](https://github.com/nesquena/hermes-webui) — the open-source browser UI for Hermes Agent.

### Changes

1. **New module** `nix/modules/nixos/hermes-webui.nix` — systemd service definition that:
   - Fetches the webui source from GitHub
   - Extracts the agent's venv Python from the hermes wrapper (already has pyyaml + agent modules)
   - Runs `server.py` as the `hermes` user

2. **hermes-agent container** — imports the module and enables it on port 8787

3. **Dex Traefik** — new router + service: `hermes-webui.dex-lips.duckdns.org` → container `10.1.1.2:8787` with Let's Encrypt TLS

### Why

Same pattern as the built-in `hermes dashboard` (already deployed) — browser access to Hermes Agent from the web or phone.