### PR TITLE
add devenv for agent-managed tool dependencies

### DIFF
--- a/nix/systems/hermes-agent/configuration.nix
+++ b/nix/systems/hermes-agent/configuration.nix
@@ -26,7 +26,7 @@
     ++ [
       go
       python3
-      # Hermes can make a pr to add any extra packages it needs here
+      devenv  # agent manages own tool deps via ~/.hermes/devenv.nix
     ];
 
   # Mirror the host's nix experimental-features so any agent-driven nix


### PR DESCRIPTION
Adds `devenv` to the hermes-agent container's system packages so the agent can manage its own tool dependencies via `~/.hermes/devenv.nix` instead of requiring PRs for every new tool.

This is the last PR needed for tool management — from here on, the agent just edits `devenv.nix` to add python3, curl, jq, etc. without any NixOS rebuild.